### PR TITLE
Fixes #3: Duplicate Action Bars

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,8 +4,10 @@
     <option name="filePathToZoomLevelMap">
       <map>
         <entry key="presentation/src/main/res/layout/activity_cocktails.xml" value="0.28229166666666666" />
+        <entry key="presentation/src/main/res/layout/fragment_blank.xml" value="0.35104166666666664" />
         <entry key="presentation/src/main/res/layout/fragment_cock_tails.xml" value="0.28229166666666666" />
         <entry key="presentation/src/main/res/layout/item_cocktail.xml" value="0.1" />
+        <entry key="presentation/src/main/res/layout/item_cocktail_shimmer.xml" value="0.3515625" />
       </map>
     </option>
   </component>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.CockTails" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.CockTails" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_200</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.CockTails" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.CockTails" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_500</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     dependencies {
 
         classpath deps.build_tools
-        classpath deps.kotlin_plugin
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21"
         classpath deps.ktlint
         classpath deps.detekt
         classpath deps.ben_manes

--- a/presentation/src/main/java/com/example/presentation/fragments/CockTailsFragment.kt
+++ b/presentation/src/main/java/com/example/presentation/fragments/CockTailsFragment.kt
@@ -15,6 +15,7 @@ import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.core.Constants.DEFAULT_CALL
 import com.example.core.Status
+import com.example.presentation.R
 import com.example.presentation.adapter.CockTailAdapter
 import com.example.presentation.databinding.FragmentCockTailsBinding
 import com.example.presentation.viemodel.CockTailViewModel
@@ -46,7 +47,7 @@ class CockTailsFragment : Fragment() {
         val layout = binding.collapsingToolbarLayout
 
         // toolbar title not responsive ignore for now
-        //  toolbar.setTitle("my title")
+        toolbar.title = "Cocktails"
 
         layout.setupWithNavController(toolbar, navController, appBarConfiguration)
         super.onViewCreated(view, savedInstanceState)

--- a/presentation/src/main/res/layout/fragment_cock_tails.xml
+++ b/presentation/src/main/res/layout/fragment_cock_tails.xml
@@ -11,33 +11,29 @@
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appbarLayout"
         android:layout_width="match_parent"
-        android:layout_height="240dp">
+        android:layout_height="wrap_content">
 
         <com.google.android.material.appbar.CollapsingToolbarLayout
             android:id="@+id/collapsingToolbarLayout"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-            app:contentScrim="?attr/colorPrimary"
-            app:expandedTitleGravity="top"
+            app:contentScrim="?attr/colorPrimaryDark"
+            app:expandedTitleGravity="bottom"
             app:layout_scrollFlags="scroll|exitUntilCollapsed|snap">
 
             <ImageView
                 android:layout_width="match_parent"
-                android:layout_height="250dp"
+                android:layout_height="240dp"
                 android:src="@drawable/cocktails"
                 app:layout_collapseMode="parallax"
                 android:adjustViewBounds="true"
-                android:scaleType="fitXY"
-                tools:ignore="ImageContrastCheck"/>
+                android:scaleType="centerCrop"/>
 
             <androidx.appcompat.widget.Toolbar
                 android:id="@+id/toolBar"
                 android:layout_width="match_parent"
-                android:layout_height="?attr/actionBarSize"
-                android:elevation="4dp"
-                android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
-
+                android:layout_height="?attr/actionBarSize"/>
 
         </com.google.android.material.appbar.CollapsingToolbarLayout>
     </com.google.android.material.appbar.AppBarLayout>


### PR DESCRIPTION
Fixes duplicare action bars, one in the main theme and the other in the fragment.
Removes the one in the theme and leaves the one in the fragment. 
Changes the height and titlebar color.

# Expanded
![Screenshot from 2022-06-06 15-41-09](https://user-images.githubusercontent.com/40160345/172162517-20437b93-ee62-40f9-b537-7441c15832df.png)

# Collapsed
![Screenshot from 2022-06-06 15-41-17](https://user-images.githubusercontent.com/40160345/172162556-9eb614d7-db99-45fe-9b94-55b134e2a3b3.png)

closes #3 
