### PR TITLE
item_coctail.xml Card view Image and Text view Center alignment

### DIFF
--- a/presentation/src/main/res/layout/item_cocktail.xml
+++ b/presentation/src/main/res/layout/item_cocktail.xml
@@ -14,8 +14,11 @@
 
         <ImageView
             android:id="@+id/cockTailImage"
-            android:layout_width="150dp"
+            android:layout_width="0dp"
             android:layout_height="160dp"
+            android:adjustViewBounds="true"
+            android:scaleType="centerCrop"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"/>
 
@@ -25,10 +28,12 @@
             android:layout_height="wrap_content"
             app:layout_constraintTop_toBottomOf="@id/cockTailImage"
             app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             android:textStyle="bold"
             tools:text="CockTails"
-            android:layout_marginStart="20dp"
-            />
+            android:textAlignment="center"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="8dp"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.cardview.widget.CardView>


### PR DESCRIPTION
The image view displaying the cocktails image has been centered to fit the card view like shown on the screenshot below while the text view has been centered below the cocktails image. This gives the recycled item more symmetrical and appealing on the screen.


![Screenshot_20220607-155301 1](https://user-images.githubusercontent.com/38817564/172385339-31f8aaac-9559-4245-a033-99ad2e702cde.png)
.